### PR TITLE
Detect and ignore detached DOM nodes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -24,7 +24,7 @@ function setup(el, binding) {
 
                 if (event.keyCode) {
                     event.keyCode === 27 && callback();
-                } else if (!(event.target === el) && !el.contains(event.target)) {
+                } else if (!(event.target === el) && !el.contains(event.target) && isMounted(event.target)) {
                     callback();
                 }
 
@@ -45,6 +45,12 @@ function setup(el, binding) {
 
     }
 
+}
+
+function isMounted(node) {
+    if (node.nodeType === Node.DOCUMENT_NODE) return true;
+    if (node.parentNode == undefined) return false;
+    return isMounted(node.parentNode);
 }
 
 function unbind(el) {


### PR DESCRIPTION
Improve the code so it ignores elements clicked if they vanish from the DOM on click, otherwise if you click something inside the parent wrapper which removes itself on click the element.contains(target) will fail as it is gone even if it was there originally since it's own click handler will have triggered first